### PR TITLE
Fix wrong `ProvidesClass` entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ LaTeX Style für Dissertationen der Schriftenreihe Stuttgarter Maschinenbau (SMB
     - [Spätere Ordnersturkur des Diss-Ordners](#spätere-ordnersturkur-des-diss-ordners)
   - [FAQ](#faq)
     - [Wie melde ich einen Fehler?](#wie-melde-ich-einen-fehler)
+    - [Ich bekomme eine Warnung `You have requested document class 'isw_smb_diss/isw_smb_diss', but the document class provides 'isw_smb_diss'.`](#ich-bekomme-eine-warnung-you-have-requested-document-class-isw_smb_dissisw_smb_diss-but-the-document-class-provides-isw_smb_diss)
 
 ## Anleitung zum Aufsetzen meiner Dissertation 
 
@@ -83,3 +84,9 @@ Diss/
 - Als [Issue aus GitHub](https://github.com/iswunistuttgart/isw_smb_diss/issues/new)
 - Noch besser: direkt auf einem Branch beheben und einen [pull request](https://github.com/iswunistuttgart/isw_smb_diss/compare) stellen
 - Für Änderungen gibt es keine Merge-Garantie, daher am besten vorher besprechen
+
+### Ich bekomme eine Warnung `You have requested document class 'isw_smb_diss/isw_smb_diss', but the document class provides 'isw_smb_diss'.`
+
+Siehe auch [PR:  Fix wrong ProvidesClass entry #5](https://github.com/iswunistuttgart/isw_smb_diss/pull/5)
+
+Entsteht, indem die Latex-Klasse aus einem Unterordner eingebunden wird (z.B. als [Git Submodule](#weg-1-als-git-submodule-ohne-overleaf)). Die Klasse sollte trotzdem funktionieren. Die Warnung kann behoben werden, indem dieses Repository [installiert wird](https://tex.stackexchange.com/questions/10498/installing-a-class), oder der Pfad der Klasse in die Umgebungsvariable [`TEXINPUTS`](https://tex.stackexchange.com/questions/153135/how-to-store-the-documents-style-file-in-a-subdirectory/153138#153138) aufgenommen wird. (Danach `\documentclass[...]]{isw_smb_diss/isw_smb_diss}` ändern zu `\documentclass[...]]{isw_smb_diss}`)

--- a/isw_smb_diss.cls
+++ b/isw_smb_diss.cls
@@ -1,6 +1,6 @@
 % basiert auf der Vorlage von O. Gerlach (2015), erweitert von C. Hinze (2020/2021)
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{isw_smb_diss/isw_smb_diss}[2021/12/01 v. 1.4 Stuttgarter-Maschinenbau-Reihe für Dissertationen: https://git.isw.uni-stuttgart.de/projekte/eigenentwicklungen/templates/isw_smb_diss]
+\ProvidesClass{isw_smb_diss}[2021/12/01 v. 1.4 Stuttgarter-Maschinenbau-Reihe für Dissertationen: https://git.isw.uni-stuttgart.de/projekte/eigenentwicklungen/templates/isw_smb_diss]
 \typeout{}
 \typeout{Stuttgarter Maschinenbau Dissertation LaTeX template class }
 \typeout{}


### PR DESCRIPTION
The value of `\ProvidesClass` must be only the class name, not containing any subdirectories or other entries. The old value of `isw_smb_diss/isw_smb_diss` is incorrect and must just read `isw_smb_diss`.
Otherwise, the compiler complains that `requested class 'isw_smb_diss' but the class provides 'isw_smb_diss/isw_smb_diss'`

This patch fixes this.