### PR TITLE
Fix: \oralexamination should not be printed without the accepted flag

### DIFF
--- a/isw_smb_diss.cls
+++ b/isw_smb_diss.cls
@@ -17,7 +17,7 @@
 \newcommand{\introstart}{Der Fakultät}
 \newcommand{\introstatus}{vorgelegte}
 \newcommand{\documentsourceintro}{von}
-\newcommand{\oralexamination}{Tag der mündlichen Prüfung: \>\\}
+\newcommand{\oralexamination}{\\}
 \newcommand{\linkcolor}{uniSblue}
 
 \DeclareOption{smallfont}{


### PR DESCRIPTION
This was introduced by PR #4 but the string seems to have snuck back in, in a later commit.