### PR TITLE
Switch final paper format to a4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,14 @@
+# 1.10 -- 2026-01-17
+
+- [class] to minimize layout issues after adding the `accepted` class option, definition of `accepted` was changed to just change the title page. 
+          To print all links in black use option `print` from now on. 
+          Paper format will stay in A4 and the publisher should just scale the A4 pages to A5 paper for the final print of your dissertation.
+          For true DIN-A5 format there is an additional class option `a5paper` now. Be warned that the change might lead to layout issues
+- [glossaries] [MR #15](https://github.com/iswunistuttgart/isw_smb_diss/pull/15 ) by [@wolfmar](https://github.com/wolfmar) removes a temporary workaround for `automake`option of package `glossaries-extra`, which is not needed anymore as of latex versions 2025+ 
+- [readme] adapted to changed class
+
 # 1.9 -- 2024-11-08
+
 - [class] add class option print (currently turns links black for printing first version)
 - [class] As requested by the publisher, all section headings have the same indentation now
 - [example] Use \raggebottom for pages to avoid future headache (publisher wants this explicitly)
@@ -14,14 +24,14 @@ Futher feedback from publishing:
 
 - [class] Fix headline: Was empty on one side of the book when no section defined in chapter (default komascript style). Publisher requested to have chapter on both page headings then
 - [class] Fix literature entries should not break between pages in final mode (with class option `accepted`)
-- [example] Fix TexStuio magic comments to build automatically with biber 
+- [example] Fix TexStudio magic comments to build automatically with biber 
 
 # 1.7 -- 2023-10-10
 
 Feedback from pubishing of colleagues:
 
 - [readme] Provide some help for publishing process in the [Readme's FAQ section](https://github.com/iswunistuttgart/isw_smb_diss/blob/master/README.md#faq)
-- [class] Go back from manaual setting page geometry, use komascript's native one instead
+- [class] Go back from manual setting page geometry, use komascript's native one instead
 - [example] Add option for ragged bottom
 - [example] Add option to force avoid bibliography entry splitting on two pages
 
@@ -37,7 +47,7 @@ Feedback from publishing my dissertation:
 
 - [class] Fix footnotes appearing outside of type area
 - [class] English title is added on title page  as required by faculty now (https://www.f07.uni-stuttgart.de/forschung/promotion-und-habilitation/promotion/dokumente/Titelblatt-Dissertation-1Einreichung_2Drucklegung.pdf)
-- [example] Work on apppendix format
+- [example] Work on appendix format
 - [example] Fix running head of bibliography only appearing on even pages (solution is to add the bibliography to toc with class option "toc=bib," and not to call "heading=bibintoc" in \printbibliography)
 - [example] Some cleanup
 - [example] Provide example for glossary settings

--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ Diss/
 
 ### Optionen zum Konfigurieren der Klasse `isw_smb_diss.cls`
 
-1. `smallfont` ... kleinere Schrift: 12pt auf A4, 8pt auf A5
+1. `smallfont` ... kleinere Schrift: 12pt auf A4, (entspricht ~8.5pt bei A5-Druck)
 2. `onside|twoside`  ... einseitiger/doppelseitiger Druck.  `oneside` ist für das Drucken des Manuskripts gedacht und nimmt an, dass alle Seiten rechte Seiten sind (Kopf und Seitenzahlen immer rechts). Die finale Veröffentlichung mit dem Verlag sollte mit `twoside` erfolgen.
 3. `BCOR=XYmm` ... Bindungskorrektur. Der Textblock wird nach außen gerückt, um die Lesbarkeit bei Klebebindung zu verbessern. Methoden zur Ermittlung des Wertes finden Sie [hier](https://tex.stackexchange.com/a/38700) Tipp: Messen Sie in der Bibliothek eine Dissertation des Verlags mit einer ähnlichen Seitenanzahl. Für ca. 200 Seiten waren 6mm okay.
-4. `accepted` ... für die finale Druckversion (siehe auch [in den FAQs](https://github.com/iswunistuttgart/isw_smb_diss/blob/master/README.md#unterscheidet-das-template-zwischen-einreichung-und-ver%C3%B6ffentlichung-beim-verlag)). Das Format wird auf Din-A5 gestellt, die Schriftgröße entsprechend skaliert. Das Deckblatt wird entsprechend der Prüfungsordnung angepasst.
+4. `accepted` ... für die finale Druckversion (siehe auch [in den FAQs](https://github.com/iswunistuttgart/isw_smb_diss/blob/master/README.md#unterscheidet-das-template-zwischen-einreichung-und-ver%C3%B6ffentlichung-beim-verlag)). Das Deckblatt wird entsprechend der Prüfungsordnung für den finalen Druck angepasst. Um beim Druck nicht alle Verlinkungen in Uni-Stuttgart-Blau zu haben (teuer, viele Farbseiten), siehe außerdem nachfolgende Option
 5. `print` ... schwarz einfärben von Links für den Druck des Manuskripts (weniger Farbseiten)
+6. `a5paper` ... Das Format wird auf DIN-A5 gestellt, die Schriftgröße entsprechend skaliert (nicht empfohlen, führt wahrscheinlich zu Anpassungsbedarf durch Layoutumstellung).
 
 Beispiel für Einbinden der Klasse:
 
@@ -116,29 +117,17 @@ Beispiel für Einbinden der Klasse:
 
 ### Unterscheidet das Template zwischen Einreichung und Veröffentlichung beim Verlag?
 
-Ja, nach den [Vorgaben der Uni](http://dx.doi.org/10.18419/opus-10327) soll das Manuskript in A4-Format eingereicht werden, das Format für den Druck ist aber "in der Regel DIN A5". Für die Umschaltung in das Druckformat muss die Klassenoption `accepted` übergeben werden, also
+Ja, nach den [Vorgaben der Uni](http://dx.doi.org/10.18419/opus-10327) soll das Manuskript in A4-Format eingereicht werden, das Format für den Druck ist aber "in der Regel DIN A5". Für die Umschaltung in das Druckformat (anderes Deckblatt, siehe Prüfungsprdnung) muss die Klassenoption `accepted` übergeben werden, also
 
 ```latex
-\documentclass[accepted, english, ngerman]{isw_smb_diss/isw_smb_diss}
+\documentclass[accepted, print, english, ngerman]{isw_smb_diss/isw_smb_diss}
 ```
 
-Diese ändert auch die Link-Farben in schwarz um die Druckkosten zu reduzieren (weniger Farbseiten).
+Die zusätzliche Option ändert die Link-Farben in schwarz um die Druckkosten zu reduzieren (weniger Farbseiten).
 
-Um die Komplikationen (und den Anpassungsbedarf) der Änderung im Papierformat möglichst gering zu halten, werden Schriftgröße und Seitenränder so angepasst, dass das Format möglichst gleich bleibt. 
+Um die Komplikationen (und den Anpassungsbedarf) der Änderung im Papierformat möglichst gering zu halten, wird das Format auch bei `accepted` in A4 gelassen. Der Verlag sollte für die finale Dissertation dementsprechend die Inhalte auf A5 skalieren.
 
-Um Probleme bei der Umstellung zu vermeiden, sollten in Abbildungen und Tabellen [*relative Maßeinheiten*](https://www.overleaf.com/learn/latex/Lengths_in_LaTeX) verwendet werden, z.B:
-
-```latex
-%for tables
-\begin{tabular}{p{4em} p{5em} c c}
-% ...
-\end{tabular}
-
-% graphics
-\includegraphics[width=0.8\textwidth]{path/to/my_picture}
-
-% TikZ pictures: https://tex.stackexchange.com/questions/4338/correctly-scaling-a-tikzpicture
-```
+Wird tatsächlich A5-Format gefordert, kann die Umstellung mit der Klassenoption `a5paper` erfolgen.
 
 ### Wie melde ich einen Fehler?
 

--- a/diss_beispiel.tex
+++ b/diss_beispiel.tex
@@ -1,4 +1,3 @@
-% !TeX document-id = {2e27ddd9-8725-4684-b0b8-a4328d10ae60}
 % !TeX program = txs:///lualatex
 % !TEX spellcheck = de-DE
 % !BIB program = txs:///biber
@@ -10,8 +9,9 @@
 english, ngerman,% Language: last one is the main language used in the document
 %smallfont, % if you wish a smaller font. This is 12pt for the manuscript, 
 twoside, % one of {oneside, twoside} -> onesided or twosided layout. for twosided print choose twoside
-toc=bib,
+toc=bib, % have  bibliography listed in table of contents
 BCOR=6mm, % binding correction, 6 mm for 200 pages, 80 g/m² Paper (half of thickness of book content)
+%a5paper, %  change paper format to true DIN-A5 (default is DIN-A4). This might lead to layout issues after conversion, prefer offloading scaling to A5 to printer
 ]{isw_smb_diss} % Relative path to class. If class is in subfolder (e.g. as git submodule) then \documentclass[...]{isw_smb_diss/isw_smb_diss}
 
 % Rules for the design of your dissertation: http://dx.doi.org/10.18419/opus-10327 (S. 25)
@@ -127,8 +127,8 @@ isbn=true]{biblatex}
 \faculty{Konstruktions-, Produktions- und Fahrzeugtechnik} % Fak. 7
 % \faculty{Energie-, Verfahrens- und Biotechnik} % Fak. 4
 \institute{Institut für Steuerungstechnik der Werkzeugmaschinen und Fertigungseinrichtungen}
-\dateoforalexamination{1. Januar 2024}
-\yearofpublication{2024}
+\dateoforalexamination{1. Januar 2027}
+\yearofpublication{2027}
 
 % Manual hyphenation. 
 % More info for German hyphenation in LaTeX: https://de.wikibooks.org/wiki/LaTeX-W%C3%B6rterbuch:_Silbentrennung

--- a/isw_smb_diss.cls
+++ b/isw_smb_diss.cls
@@ -1,9 +1,9 @@
 % basiert auf den Vorlagen von O. Gerlach (2015) und Philipp Tempel (2018) erweitert von C. Hinze (2020-2024)
 % Richtlinien zur Formatierung der Dissertation: http://dx.doi.org/10.18419/opus-10327
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{isw_smb_diss}[2024/11/08 v. 1.9 Stuttgarter-Maschinenbau-Reihe für Dissertationen: https://github.com/iswunistuttgart/isw_smb_diss]
+\ProvidesClass{isw_smb_diss}[2026/01/17 v. 1.10 Stuttgarter-Maschinenbau-Reihe für Dissertationen: https://github.com/iswunistuttgart/isw_smb_diss]
 \typeout{}
-\typeout{Stuttgarter Maschinenbau Dissertation LaTeX template class v1.9}
+\typeout{Stuttgarter Maschinenbau Dissertation LaTeX template class v1.10}
 \typeout{}
 \typeout{Institute for Control Engineering of Machine Tools and Manufacturing}
 \typeout{Units, ISW, Seidenstrasse 36, D-70174 Stuttgart, Germany.}
@@ -29,14 +29,6 @@
 	\renewcommand{\introstatus}{genehmigte}
 	\renewcommand{\documentsourceintro}{Vorgelegt von}
 	\renewcommand{\oralexamination}{Tag der mündlichen Prüfung: \> \@dateoforalexamination \\}
-	\renewcommand{\documentfontsize}{10pt}
-	\renewcommand{\paperformatScr}{a5}
-	\renewcommand{\paperformatGeom}{a5paper}
-	\renewcommand{\linkcolor}{black}
-	
-	\DeclareOption{smallfont}{
-		\renewcommand{\documentfontsize}{8pt}% 8.5 would be closer, but is not supported. Scale a little smaller to avoid overflowing floating environments.
-	}
 	
 	% This avoids page breaks within bibliography entries
 	\AtBeginDocument{%
@@ -46,6 +38,15 @@
 
 \DeclareOption{print}{
 	\renewcommand{\linkcolor}{black}
+}
+
+\DeclareOption{a5paper}{
+	\renewcommand{\documentfontsize}{10pt}
+	\renewcommand{\paperformatScr}{a5}
+	\renewcommand{\paperformatGeom}{a5paper}	
+	\DeclareOption{smallfont}{
+		\renewcommand{\documentfontsize}{8pt}% 8.5 would be closer, but is not supported. Scale a little smaller to avoid overflowing floating environments.
+	}
 }
 
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{scrbook}}


### PR DESCRIPTION
- class option `accepted` just changes the title page now
- use class option `print`to get black links for printing
- use `a5paper` (not recommended) to additionally switch to true a5 paper format