### PR TITLE
Improve equations numbering in appendix (starts at 1)

### DIFF
--- a/isw_smb_diss.cls
+++ b/isw_smb_diss.cls
@@ -276,6 +276,8 @@ draft=false,]{scrlayer-scrpage}	 % header & footer layout
 \automark[section]{section} %Fix the headline: chapter -> section, section -> subsection
 \automark*[subsection]{}
 
+\numberwithin{equation}{section} %Ensure that equations enumeration starts at 1
+
 \makeatletter
 \renewcommand{\@seccntformat}[1]{Anhang \csname the##1\endcsname\quad} % Sections start with "Anhang", e.g. "Anhang A.1" (but not in table of contents)
 \makeatother


### PR DESCRIPTION
This PR ensures that the equation numbering in Appendix starts with 1, and in the form (A.1), (A.2) and (B.1) (B.2) etc. depending on the actual Appendix section. Before this change, it was (.1) (.2) (.3) ... for all appendices